### PR TITLE
fix bug where viz crashes when MME=0: fixes #4

### DIFF
--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -26,7 +26,11 @@ HTMLWidgets.widget({
             max: d3.max(opts.data, d => d.x)
         };
 
-        distParams.cuts = [-opts.MME, opts.MME, distParams.max];
+        if (opts.MME === 0) {
+            distParams.cuts = [opts.MME, distParams.max];
+        } else {
+            distParams.cuts = [-opts.MME, opts.MME, distParams.max];
+        }
 
         opts.data = opts.data.sort((a,b) => a.x - b.x);
 
@@ -171,7 +175,7 @@ HTMLWidgets.widget({
 
         var toggle = function(to, duration) {
             if (to === "distribution") {
-                updateYAxis(dataContinuousGroups[0].data.concat(dataContinuousGroups[1].data).concat(dataContinuousGroups[2].data), 0);
+                updateYAxis(opts.data, 0);
                 updateXAxis("continuous", duration);
 
                 areas


### PR DESCRIPTION
Added some logic to deal with the case where MME=0 (thus only 2 categories). Before some of the code was relying on there being 3 categories (negative, negligible, positive), which was causing a crash when MME=0 (issue #4 ). Now the app should work with MME=0.