### PR TITLE
fix crash when all probability falls in single bucket: fixes #8

### DIFF
--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -46,9 +46,11 @@ HTMLWidgets.widget({
                 }
             });
 
-            data.unshift({x:data[0].x, y:0});
-            data.push({x:data[data.length - 1].x, y:0});
-
+            if (data.length > 0) {
+                data.unshift({x:data[0].x, y:0});
+                data.push({x:data[data.length - 1].x, y:0});
+            }
+            
             dataContinuousGroups.push({
                 color: opts.colors[i],
                 data: data


### PR DESCRIPTION
This fixes the bug you identified in issue #8. Before, the app would crash if there was a bin with 0 probability (not caused by MME=0). Now these cases display properly, with no crashes.