### PR TITLE
animate appearance of threshold bar - float in: closes #11

### DIFF
--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -151,9 +151,9 @@ HTMLWidgets.widget({
             .style("stroke-dasharray", "5,5")
             .style("opacity", 1)
             .attr("x1", 0)
-            .attr("y1", y(opts.threshold))
+            .attr("y1", y(0))
             .attr("x2", dims.width)
-            .attr("y2", y(opts.threshold));
+            .attr("y2", y(0));
 
 
         var updateXAxis = function(type, duration) {
@@ -196,7 +196,9 @@ HTMLWidgets.widget({
                         });
 
                 thresholdLine
-                    .style("opacity", 0);
+                    .style("opacity", 0)
+                    .attr("y1", y(0))
+                    .attr("y2", y(0));
 
                 g.select(".y.axis")
                     .style("opacity", 0);
@@ -227,9 +229,10 @@ HTMLWidgets.widget({
 
                 thresholdLine
                     .transition()
-                    .duration(0)
                     .delay(duration)
                         .style("opacity", 1)
+                    .transition()
+                    .duration(1000)
                         .attr("y1", y(opts.threshold))
                         .attr("y2", y(opts.threshold));
 


### PR DESCRIPTION
This PR addresses issue #11 and changes the animation between the distribution and the bars to the following:
1. Sections of the distribution morph into bars
2. Upon completion of (1), Y-axis appears
3. Upon completion of (1), threshold line appears at y=0 and floats up to threshold value