### PR TITLE
Options for title.

### DIFF
--- a/R/IMPosterior.R
+++ b/R/IMPosterior.R
@@ -22,6 +22,7 @@ IMPosterior <- function(prior = NULL, posterior = NULL, MME = 0, threshold = NUL
                         breaks=NULL, break_names = NULL, colors = NULL,
                         width = NULL, height = NULL,
                         xlim = NULL,
+                        title = FALSE, subtitle = '',
                         elementId = NULL) {
   if(MME<0) stop("MME should be greater than 0")
   if (!is.null(breaks) & MME!=0) stop('MME and breaks cannot both be specified')
@@ -131,7 +132,9 @@ IMPosterior <- function(prior = NULL, posterior = NULL, MME = 0, threshold = NUL
     start_status = 'distribution',
     initial_trans = TRUE,
     allow_mode_trans = allow_mode_trans,
-    xlim = xlim
+    xlim = xlim,
+    title = title,
+    subtitle = subtitle
   )
 
   # Define sizing policy

--- a/R/IMPosterior.R
+++ b/R/IMPosterior.R
@@ -22,7 +22,7 @@ IMPosterior <- function(prior = NULL, posterior = NULL, MME = 0, threshold = NUL
                         breaks=NULL, break_names = NULL, colors = NULL,
                         width = NULL, height = NULL,
                         xlim = NULL,
-                        title = FALSE, subtitle = '',
+                        display_mode_name = FALSE, title = '',
                         elementId = NULL) {
   if(MME<0) stop("MME should be greater than 0")
   if (!is.null(breaks) & MME!=0) stop('MME and breaks cannot both be specified')
@@ -133,8 +133,8 @@ IMPosterior <- function(prior = NULL, posterior = NULL, MME = 0, threshold = NUL
     initial_trans = TRUE,
     allow_mode_trans = allow_mode_trans,
     xlim = xlim,
-    title = title,
-    subtitle = subtitle
+    display_mode_name = display_mode_name,
+    title = title
   )
 
   # Define sizing policy

--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -168,7 +168,7 @@ HTMLWidgets.widget({
                     .scaleLinear()
                     .domain(xDomain)
                     .range([0, dims.width]);
-				
+
 				// Clamp - otherwise the xlim won't cut off sharply
 				xContinuous.clamp(true);
 
@@ -218,6 +218,16 @@ HTMLWidgets.widget({
                     .style('text-anchor', 'middle')
                     .style('font-size', 14 + 'px')
                     .text(opts.xlab||'');
+
+        // Define title - may not actually show
+        let titleg = svg
+                    .append('g')
+                    .attr('transform', 'translate(' + margin.left + ',0)');
+
+          titleg.append('text')
+                .style('text-anchor','left')
+                .style('font-size', 14 + 'px')
+                .text('Prior Distribution');
 
 
                 // create axes

--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -234,23 +234,23 @@ HTMLWidgets.widget({
 				
 				var mode_title;
 				var subtitle;
-				if (opts.title) {
+				if (opts.display_mode_name) {
 					mode_title = titleg.append('text')
 						.style('text-anchor','left')
 						.style('alignment-baseline', 'hanging')
 						.style('font-size', 20 + 'px')
 						.style('opacity',1)
-						.text(`${str_proper(MODE)} Distribution`);
+						.text(`${str_proper(MODE)} ${STATUS=='discrete' ? 'Probability' : 'Distribution'}`);
 				}
 				
-				if (opts.subtitle != null) {
+				if (opts.title != null) {
 					sub_title = titleg.append('text')
 						.style('text-anchor','left')
 						.style('alignment-baseline', 'hanging')
 						.style('font-size', 20 + 'px')
 						.style('opacity',1)
-						.attr('dy',`${20*opts.title}px`)
-						.text(opts.subtitle);
+						.attr('dy',`${20*opts.display_mode_name}px`)
+						.text(opts.title);
 				}
 
                 // create axes
@@ -409,6 +409,22 @@ HTMLWidgets.widget({
 
                 // function to switch between bars and distribution
                 let toggle_status = (to, duration) => {
+					
+					// Fade out, change, fade back
+					if (opts.display_mode_name) {
+						mode_title
+							.interrupt()
+							.style('opacity',1)
+							.transition()
+							.duration(duration/2)
+							.style('opacity',0)
+							.transition()
+							.delay(duration/2)
+							.duration(duration/2)
+							.text(`${str_proper(MODE)} ${to=='discrete' ? 'Probability' : 'Distribution'}`)
+							.style('opacity',1);
+					}
+					
                     if (to === 'distribution') {
                         // update axes
                         updateYAxis(opts.dens, 0);
@@ -494,7 +510,7 @@ HTMLWidgets.widget({
 					mode_button.classed('active',MODE=='posterior');
 					
 					// Fade out, change, fade back
-					if (opts.title) {
+					if (opts.display_mode_name) {
 						mode_title
 							.interrupt()
 							.style('opacity',1)
@@ -504,7 +520,7 @@ HTMLWidgets.widget({
 							.transition()
 							.delay(duration/2)
 							.duration(duration/2)
-							.text(`${str_proper(MODE)} Distribution`)
+							.text(`${str_proper(MODE)} ${STATUS=='discrete' ? 'Probability' : 'Distribution'}`)
 							.style('opacity',1);
 					}
 

--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -219,16 +219,37 @@ HTMLWidgets.widget({
                     .style('font-size', 14 + 'px')
                     .text(opts.xlab||'');
 
-        // Define title - may not actually show
-        let titleg = svg
-                    .append('g')
-                    .attr('transform', 'translate(' + margin.left + ',0)');
-
-          titleg.append('text')
-                .style('text-anchor','left')
-                .style('font-size', 14 + 'px')
-                .text('Prior Distribution');
-
+				// Proper case function
+				let str_proper = (str) => {
+					let first = str.substring(0,1).toUpperCase();
+					let rest = str.substring(1,9999).toLowerCase();
+					return(first + rest);
+				}
+				
+				// Define title - may not actually show
+				let titleg = svg
+							.append('g')
+							.attr('class','title')
+							.attr('transform', 'translate(' + margin.left + ',10)');
+				
+				var mode_title;
+				var subtitle;
+				if (opts.title) {
+					mode_title = titleg.append('text')
+						.style('text-anchor','left')
+						.style('alignment-baseline', 'hanging')
+						.style('font-size', 20 + 'px')
+						.style('opacity',1)
+						.text(`${str_proper(MODE)} Distribution`);
+						
+					sub_title = titleg.append('text')
+						.style('text-anchor','left')
+						.style('alignment-baseline', 'hanging')
+						.style('font-size', 20 + 'px')
+						.style('opacity',1)
+						.attr('dy','20px')
+						.text(opts.subtitle);
+				}
 
                 // create axes
                 g
@@ -469,6 +490,21 @@ HTMLWidgets.widget({
 					// Update mode and activate/deactivate button
 					MODE = to;
 					mode_button.classed('active',MODE=='posterior');
+					
+					// Fade out, change, fade back
+					if (opts.title) {
+						mode_title
+							.interrupt()
+							.style('opacity',1)
+							.transition()
+							.duration(duration/2)
+							.style('opacity',0)
+							.transition()
+							.delay(duration/2)
+							.duration(duration/2)
+							.text(`${str_proper(MODE)} Distribution`)
+							.style('opacity',1);
+					}
 
 					if (STATUS === 'discrete') {
                         areas

--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -241,13 +241,15 @@ HTMLWidgets.widget({
 						.style('font-size', 20 + 'px')
 						.style('opacity',1)
 						.text(`${str_proper(MODE)} Distribution`);
-						
+				}
+				
+				if (opts.subtitle != null) {
 					sub_title = titleg.append('text')
 						.style('text-anchor','left')
 						.style('alignment-baseline', 'hanging')
 						.style('font-size', 20 + 'px')
 						.style('opacity',1)
-						.attr('dy','20px')
+						.attr('dy',`${20*opts.title}px`)
 						.text(opts.subtitle);
 				}
 

--- a/inst/htmlwidgets/lib/custom-css/style.css
+++ b/inst/htmlwidgets/lib/custom-css/style.css
@@ -1,4 +1,4 @@
-.axis text, .y-axis-label, .x-axis-label {
+.title text, .axis text, .y-axis-label, .x-axis-label {
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;


### PR DESCRIPTION
Added option title. When TRUE it puts in a title that says "[Prior/Posterior] Distribution" and transitions with the graph. 

Added option subtitle. When specified, it prints the text at the top of the graph. Does not transition. It's not at all smart, so doesn't do line wrapping. If you feed it a subtitle, you have to be sure the graph is wide enough to show it on one line.

If both title and subtitle are specified, the title appears on line 1 and the subtitle appears on line 2. I'm not convinced it shouldn't be the other way.

The option names are terrible and I need to change them, but I'm not sure what to. Something like "display_mode_name" for what is currently title and maybe just title for what is currently subtitle?
