### PR TITLE
Font scaling

### DIFF
--- a/R/IMPosterior.R
+++ b/R/IMPosterior.R
@@ -21,7 +21,7 @@ IMPosterior <- function(prior = NULL, posterior = NULL, MME = 0, threshold = NUL
                         units = NULL, quantity = FALSE, xlab = NULL,
                         breaks=NULL, break_names = NULL, colors = NULL,
                         width = NULL, height = NULL,
-                        xlim = NULL,
+                        xlim = NULL, font_scale = 1,
                         elementId = NULL) {
   if(MME<0) stop("MME should be greater than 0")
   if (!is.null(breaks) & MME!=0) stop('MME and breaks cannot both be specified')
@@ -131,7 +131,8 @@ IMPosterior <- function(prior = NULL, posterior = NULL, MME = 0, threshold = NUL
     start_status = 'distribution',
     initial_trans = TRUE,
     allow_mode_trans = allow_mode_trans,
-    xlim = xlim
+    xlim = xlim,
+    font_scale = font_scale
   )
 
   # Define sizing policy

--- a/R/IMPosterior.R
+++ b/R/IMPosterior.R
@@ -133,7 +133,7 @@ IMPosterior <- function(prior = NULL, posterior = NULL, MME = 0, threshold = NUL
     initial_trans = TRUE,
     allow_mode_trans = allow_mode_trans,
     xlim = xlim,
-    font_scale = font_scale
+    font_scale = font_scale,
     display_mode_name = display_mode_name,
     title = title
   )

--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -29,11 +29,12 @@ HTMLWidgets.widget({
 				};
 
 				// Top margin fits the buttons. Always needs 10px buffer, plus height of button
+				// Bottom and left margin scale with font size to accomodate larger scales/labels
                 margin = {
                     top: 10 + 100*button_dims.scale,
                     right: 20,
-                    bottom: 80,
-                    left: 70
+                    bottom: 20 + 60*opts.font_scale,
+                    left: 40 + 30*opts.font_scale
                 };
 
                 dims = {
@@ -324,6 +325,7 @@ HTMLWidgets.widget({
                 let tooltip = d3
                     .tip()
                     .attr('class', 'd3-tip chart-data-tip')
+					.style('font-size',12*opts.font_scale + 'px')
                     .style('z-index',1050)
                     .offset([30, 0])
                     .direction('s')

--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -168,7 +168,7 @@ HTMLWidgets.widget({
                     .scaleLinear()
                     .domain(xDomain)
                     .range([0, dims.width]);
-				
+
 				// Clamp - otherwise the xlim won't cut off sharply
 				xContinuous.clamp(true);
 
@@ -207,7 +207,7 @@ HTMLWidgets.widget({
                     .attr('transform', `rotate(-90) translate(${-dims.height/2},${-margin.left + 20})`)
                     .attr('dy', '.71em')
                     .style('text-anchor', 'middle')
-                    .style('font-size', 14 + 'px')
+                    .style('font-size', 14*opts.font_scale + 'px')
                     .text('Probability');
 
 				// Define x label, if desired
@@ -216,7 +216,7 @@ HTMLWidgets.widget({
                     .attr('class', 'x-axis-label')
                     .attr('transform', `translate(${dims.width/2},${dims.height + margin.bottom/2})`)
                     .style('text-anchor', 'middle')
-                    .style('font-size', 14 + 'px')
+                    .style('font-size', 14*opts.font_scale + 'px')
                     .text(opts.xlab||'');
 
 
@@ -224,12 +224,14 @@ HTMLWidgets.widget({
                 g
                     .append('g')
                     .attr('class', 'x axis')
+                    .style('font-size',12*opts.font_scale + 'px')
                     .attr('transform', 'translate(0,' + dims.height + ')')
                     .call(xAxis);
 
                 g
                     .append('g')
                     .attr('class', 'y axis')
+                    .style('font-size',12*opts.font_scale + 'px')
                     .call(yAxis);
 
                 // function to transition areas to bars

--- a/inst/htmlwidgets/IMPosterior.js
+++ b/inst/htmlwidgets/IMPosterior.js
@@ -18,18 +18,27 @@ HTMLWidgets.widget({
                 // if width or height is 0 then use reasonable default - 400 for height, and height for width
                 height = height <= 0 ? 400 : height;
                 width = width <= 0 ? height : width;
-
-
+				
+				// Calculate how much space the titles will take up
+				const title_space = 23*opts.font_scale*((opts.title != '') + opts.display_mode_name);
+				console.log(`title space is ${title_space}`);
+				// Calculate the space the button would take up ignoring font size
+				const desired_button_size = 100*Math.max(Math.min(1,0.4+0.4*(height-300)/500),0.4);
+				console.log(`desired button size is ${desired_button_size}`);
+				// Use the larger 
+				const top_space = Math.max(title_space, desired_button_size);
+				
 				// Buttons scale between 40-80px, depending on height between 300 and 800 px
 				button_dims = {
-					scale: Math.max(Math.min(1,0.4+0.4*(height-300)/500),0.4),
+					scale: top_space/100,
 					width: 120,
 					height: 100,
 					buffer: 10
 				};
 
+				
 				// Top margin fits the buttons. Always needs 10px buffer, plus height of button
-				// Bottom and left margin scale with font size to accomodate larger scales/labels
+				// Top, bottom, and left margin scale with font size to accomodate larger scales/labels
                 margin = {
                     top: 10 + 100*button_dims.scale,
                     right: 20,
@@ -239,18 +248,18 @@ HTMLWidgets.widget({
 					mode_title = titleg.append('text')
 						.style('text-anchor','left')
 						.style('alignment-baseline', 'hanging')
-						.style('font-size', 20 + 'px')
+						.style('font-size', 20*opts.font_scale + 'px')
 						.style('opacity',1)
 						.text(`${str_proper(MODE)} ${STATUS=='discrete' ? 'Probability' : 'Distribution'}`);
 				}
 				
-				if (opts.title != null) {
+				if (opts.title != '') {
 					sub_title = titleg.append('text')
 						.style('text-anchor','left')
 						.style('alignment-baseline', 'hanging')
-						.style('font-size', 20 + 'px')
+						.style('font-size', 20*opts.font_scale + 'px')
 						.style('opacity',1)
-						.attr('dy',`${20*opts.display_mode_name}px`)
+						.attr('dy',`${20*opts.display_mode_name*opts.font_scale}px`)
 						.text(opts.title);
 				}
 

--- a/inst/htmlwidgets/lib/D3/style.css
+++ b/inst/htmlwidgets/lib/D3/style.css
@@ -13,7 +13,6 @@ g.tick line {
 }
 
 g.tick text {
-  font-size: 12px;
   fill: black;
 
 }

--- a/inst/htmlwidgets/lib/d3-tip/style.css
+++ b/inst/htmlwidgets/lib/d3-tip/style.css
@@ -9,7 +9,7 @@
   max-width:300px;
 }
 .chart-info-tip {
-  font-size:12px;
+  /*font-size:12px;*/
   font-weight:normal;
 }
 .chart-data-tip {


### PR DESCRIPTION
I added the option font_scale which directly multiplies the font size for the axis labels, titles, and tooltips. I tested it between 0.8 and 2 and it worked pretty well. The way the scaling works is it expands the margins and eats into the plot area to accommodate larger fonts, which means values like 1.5 don't look great on small plot areas, but I think that's ok. It also gets problematic when you have a lot of breaks because the categorical titles will really start to run together.