### PR TITLE
Added ability to specify a distribution as the prior.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Imports:
     glue,
     htmlwidgets,
     magrittr,
-    stats
+    stats,
+    stringr
 RoxygenNote: 6.1.1
 Suggests: 
     knitr,

--- a/R/parse_prior.R
+++ b/R/parse_prior.R
@@ -2,6 +2,7 @@ parse_prior <- function(prior = NULL) {
   if (is.null(prior) | is.numeric(prior)) {
     return(prior)
   } else if (is.character(prior)) {
+    prior <- stringr::str_to_lower(prior)
     #Check that it matches one of the distribution options
     valid_distns <- list(n = qnorm, normal = qnorm, unif = qunif, uniform = qunif, beta = qbeta, gamma = qgamma)
     #These take 2 options

--- a/R/parse_prior.R
+++ b/R/parse_prior.R
@@ -1,0 +1,35 @@
+parse_prior <- function(prior = NULL) {
+  if (is.null(prior) | is.numeric(prior)) {
+    return(prior)
+  } else if (is.character(prior)) {
+    #Check that it matches one of the distribution options
+    valid_distns <- list(n = qnorm, normal = qnorm, unif = qunif, uniform = qunif, beta = qbeta, gamma = qgamma)
+    #These take 2 options
+    if (prior=='std_normal') {
+      return(qnorm(1:1000/1001))
+    } else if (stringr::str_detect(prior,'^(n|normal|unif|uniform|beta|gamma)\\(([-0-9.]+), ?([-0-9.]+)\\)$')) {
+      matches <- stringr::str_match(prior,'^(n|normal|unif|uniform|beta|gamma)\\(([-0-9.]+), ?([-0-9.]+)\\)$')
+      fxn <- valid_distns[[matches[,2]]]
+      arg1 <- as.numeric(matches[,3])
+      arg2 <- as.numeric(matches[,4])
+      return(fxn(1:1000/1001, arg1, arg2))
+    } else if (stringr::str_detect(prior,'^halfnormal\\(([-0-9.]+), ?([-0-9.]+)\\)$')) {
+      matches <- stringr::str_match(prior,'^halfnormal\\(([-0-9.]+), ?([-0-9.]+)\\)$')
+      arg1 <- as.numeric(matches[,2])
+      arg2 <- as.numeric(matches[,3])
+      return(qnorm(0.5 + 1:1000/2001, arg1, arg2))
+    } else if (stringr::str_detect(prior,'^(t|student_t)\\(([-0-9.]+), ?([-0-9.]+), ?([-0-9.]+)\\)$')) {
+      matches <- stringr::str_match(prior,'^(t|student_t)\\(([-0-9.]+), ?([-0-9.]+), ?([-0-9.]+)\\)$')
+      arg1 <- as.numeric(matches[,3])
+      arg2 <- as.numeric(matches[,4])
+      arg3 <- as.numeric(matches[,5])
+      return(qt(1:1000/1001, arg1, arg2, arg3))
+    } else {
+      stop('prior incorrectly specified. Valid distributions are std_normal, N, normal, halfnormal, unif, uniform, beta, gamma, t, and student_t.')
+    }
+
+  #They entered something but it's not NULL, string, or numeric. Error out.
+  } else {
+    stop('prior incorrectly specified.')
+  }
+}

--- a/R/vizdraws.R
+++ b/R/vizdraws.R
@@ -42,6 +42,8 @@ vizdraws <- function(prior = NULL, posterior = NULL, MME = 0, threshold = NULL,
   if (!is.null(breaks) & !is.null(break_names) & length(break_names)<=length(breaks)) stop('Not enough break_names specified')
   if (!is.null(breaks) & !is.null(colors) & length(colors)<=length(breaks)) stop('Not enough colors specified')
 
+  prior <- parse_prior(prior)
+
   if (!is.null(xlim)) {
     xlim <- sort(xlim)
     if (length(xlim)!=2) stop ('xlim must have exactly 2 elements')


### PR DESCRIPTION
Here's a first attempt. I added a standalone program called parse_prior. I wrote the string parsing with stringr, but I'm not sure how to add that as a dependency (or if it already is). You can specify a distribution and it will use the 1/1001 to 1000/1001th percentiles of that in place of the prior draws. options are std_normal, normal, N, unif, uniform, gamma, beta, T, student_t. The R code is absolutely hideous, and still pretty dumb (e.g. I wasn't smart about which parameters are allowed to be negative) but it should work. Let me know if you find a way to break it, or if you think we should add any other options.