### PR TITLE
Add testthat and unit tests for parse_prior

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Imports:
 Suggests:
     glue,
     knitr,
-    rmarkdown
+    rmarkdown,
+    testthat
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 BugReports: https://github.com/ignacio82/vizdraws/issues

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(vizdraws)
+
+test_check("vizdraws")

--- a/tests/testthat/test-parse_prior.R
+++ b/tests/testthat/test-parse_prior.R
@@ -1,0 +1,14 @@
+test_that("normal and std_normal parsing", {
+  std_vec <- vizdraws:::parse_prior("std_normal")
+  norm_vec <- vizdraws:::parse_prior("normal(0,1)")
+  expect_equal(norm_vec, qnorm(1:1000/1001))
+  expect_identical(std_vec, norm_vec)
+  expect_length(norm_vec, 1000)
+})
+
+test_that("Student-t parsing", {
+  t_vec <- vizdraws:::parse_prior("student_t(0,1,3)")
+  expect_equal(t_vec, qt(1:1000/1001, df = 3))
+  expect_identical(t_vec, vizdraws:::parse_prior("t(0,1,3)"))
+  expect_length(t_vec, 1000)
+})


### PR DESCRIPTION
## Summary
- add `testthat` to DESCRIPTION suggests field
- add framework for running tests with testthat
- test parsing of common priors including Student-t fixes

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: package installation issues)*

------
https://chatgpt.com/codex/tasks/task_e_683fb365c760832e8c40032b9c9d078b